### PR TITLE
Update ibm_cloud_sdk_core and http gems

### DIFF
--- a/ibm_vpc.gemspec
+++ b/ibm_vpc.gemspec
@@ -29,8 +29,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
-  spec.add_runtime_dependency "http", "~> 4.1.0"
-  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.1.1"
+  spec.add_runtime_dependency "http", "~> 4.4.1"
+  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.1.3"
   spec.add_runtime_dependency "jwt", "~> 2.2.1"
 
   spec.add_development_dependency "bundler", "~> 2.1"


### PR DESCRIPTION
Pull in https://github.com/IBM/ruby-sdk-core/pull/33 to fix issues with ruby 2.7