### PR TITLE
fix(release): Some known HTTP::ConnectionError issues resolved in http 5.1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ sudo: required
 dist: focal
 
 rvm:
-- 2.5.1
 - 2.6.1
+- 2.7
+- 3.0
+- 3.1
 
 notifications:
   email: false
@@ -42,11 +44,11 @@ deploy:
    skip_cleanup: true
    on:
      branch: master
-     rvm: 2.5.1
+     rvm: 2.6.1
 
  - provider: rubygems
    api_key: $RUBYGEMS_API_KEY
    gem: ibm_vpc
    on:
-     rvm: '2.5.1'
+     rvm: '2.6.1'
      branch: master

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in ibm_vpc.gemspec
 gemspec
 
-gem "rake", "~> 12.0"
+gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"

--- a/ibm_vpc.gemspec
+++ b/ibm_vpc.gemspec
@@ -29,8 +29,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
-  spec.add_runtime_dependency "http", "~> 4.4.1"
-  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.1.3"
+  spec.add_runtime_dependency "http", "~> 5.1.1"
+  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.2.0"
   spec.add_runtime_dependency "jwt", "~> 2.2.1"
 
   spec.add_development_dependency "bundler", "~> 2.1"


### PR DESCRIPTION
* Note, there are some breaking changes in version 5.0.0:
https://github.com/httprb/http/blob/main/CHANGES.md#500-2021-05-12
* Update ibm_cloud_sdk_core to 1.2.0 for http 5.1.x support
* Bump rake dependency to support http 5.1.x
* http 5.1.1 requires ruby 2.6+, test with more modern rubies

~~NOTE 2, this PR will depend on https://github.com/IBM/ruby-sdk-core/pull/40 being merged, released, and bumping the `ibm_cloud_sdk_core` dependency in the various gemspecs in this repository.~~

Similar change as https://github.com/IBM-Cloud/ibm-cloud-sdk-ruby/pull/73