### PR TITLE
chore(release): Bump ibm_cloud_sdk_core to v1.3.0

### DIFF
--- a/ibm_vpc.gemspec
+++ b/ibm_vpc.gemspec
@@ -28,10 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
-  spec.add_runtime_dependency "http", "~> 5.1.1"
-  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.2.0"
-  spec.add_runtime_dependency "jwt", "~> 2.2.1"
+  spec.add_runtime_dependency "ibm_cloud_sdk_core", "~> 1.3.0"
 
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "dotenv", "~> 2.4"


### PR DESCRIPTION
Also remove dependencies which are directly copied from ibm_cloud_sdk_core since they don't need to be duplicated here.