### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: bionic
 
 rvm:
 - 2.7
-- 3.0
+- 3.0.6 # NOTE: there is an issue with missing development tools with 3.0.7
 - 3.1
 - 3.2
 


### PR DESCRIPTION
RVM 3.0.7 appears to be missing some development headers required for
building some C-based gems here.

Temporarily lock down to ruby 3.0.6

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
current directory:
/home/travis/.rvm/gems/ruby-3.0.7/gems/bigdecimal-3.1.8/ext/bigdecimal
/home/travis/.rvm/rubies/ruby-3.0.7/bin/ruby -I
/home/travis/.rvm/rubies/ruby-3.0.7/lib/ruby/3.0.0 -r
./siteconf20240906-11397-kaa51d.rb extconf.rb
checking for __builtin_clz()... *** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/home/travis/.rvm/rubies/ruby-3.0.7/bin/$(RUBY_BASE_NAME)

/home/travis/.rvm/rubies/ruby-3.0.7/lib/ruby/3.0.0/mkmf.rb:471:in `try_do': The
compiler failed to generate an executable file. (RuntimeError)
You have to install development tools first.
```